### PR TITLE
PLAT-637 - Set DevEx Team as CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# DevEx team are default owners for everything in the repository
+* @dignio/developer-experience-team


### PR DESCRIPTION
Sets the @dignio/developer-experience-team as code owners for all files in this repository.

This, coupled with the branch protection change "Require review from Code Owners", will ensure that DevEx must be involved in all changes in this repository, even if they're proposed by other teams with write access.

We can then give all teams Write access to this repo, so that they can help contribute!


