### PR TITLE
PLAT-645: override fargate

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -7,7 +7,7 @@ inputs:
     description: The application name
     required: true
   instance:
-    description: The instance. I.e. development
+    description: The instance running. Example here would be i.e. previews, development, api. It is used to select which node group we want to run the pod.
     required: true
   service_type:
     description: The service type. I.e. webservice
@@ -76,6 +76,7 @@ runs:
         service_type: ${{ inputs.service_type }}
         namespace: ${{ inputs.namespace }}
         docker_image: ${{ inputs.docker_image }}
+        instance: ${{ inputs.instance }}
 
         # === These are optional
         replicas: ${{ inputs.replicas }}

--- a/action.yaml
+++ b/action.yaml
@@ -54,6 +54,10 @@ inputs:
     description: Enable secrets manager. To fetch secrets you have to provide the cluster name.
     required: false
     default: 'false'
+  fargate:
+    description: If fargate should be enabled. This input will be removed when we have migrated to node groups.
+    required: false
+    default: 'true'
 
 runs:
   using: composite
@@ -82,6 +86,7 @@ runs:
         container_args: ${{ inputs.container_args }}
         secretsmanager: ${{ inputs.secretsmanager }}
         cluster_name: ${{ inputs.cluster_name }}
+        fargate: ${{ inputs.fargate }}
 
     - name: Echo the manifest output to a file
       shell: bash


### PR DESCRIPTION
When we set fargate to false, we will use the instance name within the generate manifest to make the deployment select a node group to deploy to.