### PR TITLE
Upgrade upload-artifact action version

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -103,7 +103,7 @@ runs:
       run: "echo ${{steps.generate_manifest.outputs.manifest}} | base64 --decode > $GITHUB_WORKSPACE/${{ steps.manifest.outputs.filename }}"
 
     - name: Upload the manifest as an artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: "${{ steps.manifest.outputs.filename }}"
         path: "${{ steps.manifest.outputs.filename }}"


### PR DESCRIPTION
Upgrade version of `upload-artifact` action because v2 is deprecated https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/